### PR TITLE
fix invalid metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -97,7 +97,7 @@ attribute 'ssl_certificate/service/use_hsts',
           description: 'Whether to enable HSTS in the service.',
           type: 'string',
           required: 'optional',
-          default: true
+          default: 'true'
 
 attribute 'ssl_certificate/service/use_stapling',
           display_name: 'ssl_certificate web use stapling',


### PR DESCRIPTION
For Chef < 11.12.0, numeric or boolean types are not allowed for
attribute metadata.

See https://tickets.opscode.com/browse/CHEF-4075